### PR TITLE
Fixed css positioning of left column and added support for file name with multiple .'s

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -69,6 +69,7 @@ h1 {
   width: 300px;
   overflow-y: auto;
   position: fixed;
+  left: 0;
   z-index: 100;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -24,7 +24,7 @@ function downloadZip() {
 
 function addImgToPage(image, fileName) {
   let squared_file =
-    fileName.split(".")[0] + "_squared." + fileName.split(".")[1];
+    fileName.split(".").slice(0, -1).join(".") + "_squared." + fileName.split(".").at(-1);
 
   let img_wrapper = document.createElement("div");
   img_wrapper.classList.add("img_wrapper");


### PR DESCRIPTION
There were some issues with the positioning of the left column on my Chromium browser (which was the only browser I tested in. The element appears in the center of the page instead of the left where it's supposed to be at. I haven't tested this in other browsers). So I added `left: 0` for a simple fix. 

There were also issues with files with names that have multiple `.` characters. I fixed it by changing `fileName.split(".")[0]` to `fileName.split(".").slice(0, -1).join(".")` and `fileName.split(".")[1]` to `fileName.split(".").at(-1)`. 